### PR TITLE
fix/remove-default-of-experimental-connection

### DIFF
--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -109,7 +109,6 @@ export class RunRepeater implements CommandModule {
       })
       .option('experimental-connection-reuse', {
         boolean: true,
-        default: false,
         describe: 'Configure experimental support for TCP connections reuse'
       })
       .option('daemon', {


### PR DESCRIPTION
There was conflict of params `experimental-connection-reuse` and `proxy`, because `experimental-connection-reuse` had default value