### PR TITLE
fix(configure): use ICMP to trace the path by default

### DIFF
--- a/src/Utils/Traceroute.ts
+++ b/src/Utils/Traceroute.ts
@@ -72,6 +72,8 @@ export class Traceroute {
       // 20th byte is a echo status code.
       // 0 - host was reached, got an echo replay and the port apart of replay
       // Other value means there is a problem (ex. 11 - Timeout) and our source message with the port was attached to replay
+      // In detail look up in https://en.wikipedia.org/wiki/Ping_(networking_utility)
+      // and https://en.wikipedia.org/wiki/Internet_Control_Message_Protocol
       const port =
         buffer.readUInt8(20) !== 0
           ? buffer.readUInt16BE(54)


### PR DESCRIPTION
Windows as opposite to *nix uses ICMP requests for tracing. So default request protocol was changed from UPD to ICMP.

closes #262
