### PR TITLE
fix(polling): treat `ESOCKETTIMEDOUT` as a recoverable error

### DIFF
--- a/src/Scan/BasePolling.ts
+++ b/src/Scan/BasePolling.ts
@@ -135,7 +135,8 @@ export class BasePolling implements Polling {
           'ETIMEDOUT',
           'ECONNREFUSED',
           'ENOTFOUND',
-          'EAI_AGAIN'
+          'EAI_AGAIN',
+          'ESOCKETTIMEDOUT'
         ].includes((err as RequestError).cause?.code)
     );
   }


### PR DESCRIPTION
closes #276