### PR TITLE
feat(configure): rework `NetworkTest` to execute traceroute remotely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /tmp
 /out-tsc
 /bin
-/data
 
 # dependencies
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /tmp
 /out-tsc
 /bin
+/data
 
 # dependencies
 node_modules

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "test:e2e": "cross-env TS_NODE_PROJECT=tests/tsconfig.json NODE_ENV=test mocha tests/**/*.spec.ts",
     "build": "webpack --config webpack.config.js --mode=production",
     "build:pkg": "pkg .",
-    "prepare": "is-ci || husky install"
+    "prepare": "is-ci || husky install",
+    "start": "node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts"
   }
 }

--- a/src/Handlers/Events/NetworkTest.ts
+++ b/src/Handlers/Events/NetworkTest.ts
@@ -4,9 +4,10 @@ export enum NetworkTestType {
   PING = 'ping',
   TRACEROUTE = 'traceroute'
 }
+
 export interface TracerouteTestConfig {
   readonly type: NetworkTestType.TRACEROUTE;
-  readonly url: string;
+  readonly host: string;
 }
 
 export interface PingTestConfig {

--- a/src/Handlers/Events/NetworkTest.ts
+++ b/src/Handlers/Events/NetworkTest.ts
@@ -1,8 +1,23 @@
 import { Event } from '../../Bus';
 
+export enum NetworkTestType {
+  PING = 'ping',
+  TRACEROUTE = 'traceroute'
+}
+export interface TracerouteTestConfig {
+  readonly type: NetworkTestType.TRACEROUTE;
+  readonly url: string;
+}
+
+export interface PingTestConfig {
+  readonly type: NetworkTestType.PING;
+  readonly urls: string[];
+}
+
+export type NetworkTestConfig = PingTestConfig | TracerouteTestConfig;
 export class NetworkTest implements Event {
   constructor(
     public readonly repeaterId: string,
-    public readonly urls: string[]
+    public readonly config: NetworkTestConfig
   ) {}
 }

--- a/src/Handlers/Events/NetworkTest.ts
+++ b/src/Handlers/Events/NetworkTest.ts
@@ -5,20 +5,10 @@ export enum NetworkTestType {
   TRACEROUTE = 'traceroute'
 }
 
-export interface TracerouteTestConfig {
-  readonly type: NetworkTestType.TRACEROUTE;
-  readonly url: string;
-}
-
-export interface PingTestConfig {
-  readonly type: NetworkTestType.PING;
-  readonly urls: string[];
-}
-
-export type NetworkTestConfig = PingTestConfig | TracerouteTestConfig;
 export class NetworkTest implements Event {
   constructor(
     public readonly repeaterId: string,
-    public readonly config: NetworkTestConfig
+    public readonly type: NetworkTestType,
+    public readonly input: string | readonly string[]
   ) {}
 }

--- a/src/Handlers/Events/NetworkTest.ts
+++ b/src/Handlers/Events/NetworkTest.ts
@@ -7,7 +7,7 @@ export enum NetworkTestType {
 
 export interface TracerouteTestConfig {
   readonly type: NetworkTestType.TRACEROUTE;
-  readonly host: string;
+  readonly url: string;
 }
 
 export interface PingTestConfig {

--- a/src/Handlers/Events/NetworkTest.ts
+++ b/src/Handlers/Events/NetworkTest.ts
@@ -9,6 +9,6 @@ export class NetworkTest implements Event {
   constructor(
     public readonly repeaterId: string,
     public readonly type: NetworkTestType,
-    public readonly input: string | readonly string[]
+    public readonly input: string | string[]
   ) {}
 }

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -54,7 +54,7 @@ export class NetworkTestHandler
           chunk.indexOf(ReadlinePlatform.HOST_OR_IP_QUESTION) > -1 &&
           config.type === NetworkTestType.TRACEROUTE
         ) {
-          child.stdin.write(`${config.url}${EOL}`);
+          child.stdin.write(`${config.host}${EOL}`);
         }
 
         if (chunk.indexOf(ReadlinePlatform.COMPELED_MESSAGE) > -1) {

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -55,7 +55,6 @@ export class NetworkTestHandler
           config.type === NetworkTestType.TRACEROUTE
         ) {
           child.stdin.write(`${config.url}${EOL}`);
-          resolve(this.processOutput(stdout));
         }
 
         if (chunk.indexOf(ReadlinePlatform.COMPELED_MESSAGE) > -1) {

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -55,14 +55,14 @@ export class NetworkTestHandler
           chunk.indexOf(ReadlinePlatform.HOST_OR_IP_QUESTION) > -1 &&
           config.type === NetworkTestType.TRACEROUTE
         ) {
-          let hostOrIP = '';
+          let hostname = '';
           try {
-            hostOrIP = new URL(config.host).host;
-          } catch (error) {
-            hostOrIP = config.host;
+            ({ hostname } = new URL(config.url));
+          } catch {
+            hostname = config.url;
           }
 
-          child.stdin.write(`${hostOrIP}${EOL}`);
+          child.stdin.write(`${hostname}${EOL}`);
         }
 
         if (chunk.indexOf(ReadlinePlatform.COMPELED_MESSAGE) > -1) {

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -5,6 +5,7 @@ import { ReadlinePlatform } from '../Wizard';
 import { Helpers, logger } from '../Utils';
 import { injectable } from 'tsyringe';
 import { EOL } from 'os';
+import { URL } from 'url';
 
 @injectable()
 @bind(NetworkTest)
@@ -54,7 +55,14 @@ export class NetworkTestHandler
           chunk.indexOf(ReadlinePlatform.HOST_OR_IP_QUESTION) > -1 &&
           config.type === NetworkTestType.TRACEROUTE
         ) {
-          child.stdin.write(`${config.host}${EOL}`);
+          let hostOrIP = '';
+          try {
+            hostOrIP = new URL(config.host).host;
+          } catch (error) {
+            hostOrIP = config.host;
+          }
+
+          child.stdin.write(`${hostOrIP}${EOL}`);
         }
 
         if (chunk.indexOf(ReadlinePlatform.COMPELED_MESSAGE) > -1) {

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -1,5 +1,5 @@
 import { bind, Handler } from '../Bus';
-import { NetworkTest, NetworkTestData } from './Events';
+import { NetworkTest } from './Events';
 import { NetworkTestResult } from '../Integrations';
 import { ReadlinePlatform } from '../Wizard';
 import { Helpers, logger } from '../Utils';
@@ -18,7 +18,7 @@ export class NetworkTestHandler
     return { output, repeaterId: config.repeaterId };
   }
 
-  private async getOutput(config: NetworkTestData): Promise<string> {
+  private async getOutput(config: NetworkTest): Promise<string> {
     return new Promise((resolve, reject) => {
       const args = ['configure', `--${config.type}`];
 

--- a/src/Handlers/NetworkTestHandler.ts
+++ b/src/Handlers/NetworkTestHandler.ts
@@ -41,25 +41,14 @@ export class NetworkTestHandler
 
         stdout.push(...lines);
 
-        if (
-          chunk.indexOf(ReadlinePlatform.URLS_QUESTION) > -1 &&
-          Array.isArray(config.input)
-        ) {
-          child.stdin.write(`${config.input.join(',')}${EOL}`);
+        const [first, ...rest]: string[] = [].concat(config.input);
+
+        if (chunk.indexOf(ReadlinePlatform.URLS_QUESTION) > -1) {
+          child.stdin.write(`${[first, ...rest].join(',')}${EOL}`);
         }
 
-        if (
-          chunk.indexOf(ReadlinePlatform.HOST_OR_IP_QUESTION) > -1 &&
-          typeof config.input === 'string'
-        ) {
-          let hostname = '';
-          try {
-            ({ hostname } = new URL(config.input));
-          } catch {
-            hostname = config.input;
-          }
-
-          child.stdin.write(`${hostname}${EOL}`);
+        if (chunk.indexOf(ReadlinePlatform.HOST_OR_IP_QUESTION) > -1) {
+          child.stdin.write(`${new URL(first).hostname}${EOL}`);
         }
 
         if (chunk.indexOf(ReadlinePlatform.COMPELED_MESSAGE) > -1) {


### PR DESCRIPTION
closes #310 