### PR TITLE
fix(request-executor): `unhandledRejection` when `WsRequestExecutor` cannot connect to target

### DIFF
--- a/src/RequestExecutor/WsRequestExecutor.ts
+++ b/src/RequestExecutor/WsRequestExecutor.ts
@@ -157,8 +157,7 @@ export class WsRequestExecutor implements RequestExecutor {
   }
 
   private async connect(client: WebSocket): Promise<IncomingMessage> {
-    // eslint-disable-next-line @typescript-eslint/typedef
-    const [, upgrading] = await Promise.all([
+    const [, upgrading]: [unknown, [IncomingMessage]] = await Promise.all([
       once(client, 'open'),
       once(client, 'upgrade') as Promise<[IncomingMessage]>
     ]);

--- a/src/RequestExecutor/WsRequestExecutor.ts
+++ b/src/RequestExecutor/WsRequestExecutor.ts
@@ -157,12 +157,13 @@ export class WsRequestExecutor implements RequestExecutor {
   }
 
   private async connect(client: WebSocket): Promise<IncomingMessage> {
-    const opening = once(client, 'open');
-    const upgrading = once(client, 'upgrade') as Promise<[IncomingMessage]>;
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const [, upgrading] = await Promise.all([
+      once(client, 'open'),
+      once(client, 'upgrade') as Promise<[IncomingMessage]>
+    ]);
 
-    await opening;
-
-    const [res]: [IncomingMessage] = await upgrading;
+    const [res]: [IncomingMessage] = upgrading;
 
     return res;
   }


### PR DESCRIPTION
closes #324