### PR TITLE
fix(request-executor): handshake timeout in `WsRequestExecutor`

### DIFF
--- a/src/RequestExecutor/WsRequestExecutor.spec.ts
+++ b/src/RequestExecutor/WsRequestExecutor.spec.ts
@@ -90,7 +90,7 @@ describe('WsRequestExecutor', () => {
     });
 
     it('should fail sending request by timeout', async () => {
-      when(spiedExecutorOptions.timeout).thenReturn(1);
+      when(spiedExecutorOptions.timeout).thenReturn(100);
 
       const url = `ws://localhost:${wsPort}`;
       const request = new Request({ url, headers: {} });

--- a/src/RequestExecutor/WsRequestExecutor.ts
+++ b/src/RequestExecutor/WsRequestExecutor.ts
@@ -55,7 +55,7 @@ export class WsRequestExecutor implements RequestExecutor {
       client = new WebSocket(options.url, {
         agent: this.agent,
         rejectUnauthorized: false,
-        timeout: this.options.timeout,
+        handshakeTimeout: this.options.timeout,
         headers: this.normalizeHeaders(options.headers),
         ca: options.ca,
         pfx: options.pfx,


### PR DESCRIPTION
closes #346