### PR TITLE
feat: rename project into `bright-cli`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Prepare Image Tags
         run: |
-          echo "TAG_REPEATER=brightsec/repeater" >> $GITHUB_ENV
+          echo "TAG_REPEATER=neuralegion/repeater" >> $GITHUB_ENV
 
       - name: Build Images
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,7 +172,7 @@ jobs:
         uses: ./.github/workflows/composite/npm
         with:
           registry: 'https://npm.pkg.github.com'
-          scope: '@NeuraLegion'
+          scope: '@BrightSec'
 
       - run: npm publish --tag $TAG
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./neuralegion-bright-cli-*
+          file: ./brightsec-cli-*
           tag: ${{ github.ref }}
           file_glob: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./neuralegion-nexploit-cli-*
+          file: ./neuralegion-bright-cli-*
           tag: ${{ github.ref }}
           file_glob: true
 
@@ -135,16 +135,16 @@ jobs:
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ startsWith(matrix.os, 'win') && '.\bin\nexploit-cli.exe' || './bin/nexploit-cli' }}
-          asset_name: ${{ format('nexploit-cli-{0}-x64{1}', matrix.target, startsWith(matrix.os, 'win') && '.exe' || '') }}
+          file: ${{ startsWith(matrix.os, 'win') && '.\bin\bright-cli.exe' || './bin/bright-cli' }}
+          asset_name: ${{ format('bright-cli-{0}-x64{1}', matrix.target, startsWith(matrix.os, 'win') && '.exe' || '') }}
           tag: ${{ github.ref }}
 
       - uses: svenstaro/upload-release-action@v2
         if: startsWith(matrix.os, 'win')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: .\bin\nexploit-cli.msi
-          asset_name: nexploit-cli.msi
+          file: .\bin\bright-cli.msi
+          asset_name: bright-cli.msi
           tag: ${{ github.ref }}
 
   publish:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Prepare Image Tags
         run: |
-          echo "TAG_REPEATER=neuralegion/repeater" >> $GITHUB_ENV
+          echo "TAG_REPEATER=brightsec/repeater" >> $GITHUB_ENV
 
       - name: Build Images
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN npm config -g set user $(whoami)
 
 #  add libraries needed to build os-service
 RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 \
-    && npm i -g -q @neuralegion/bright-cli@${VERSION} \
+    && npm i -g -q @brightsec/cli@${VERSION} \
     && apk del .build-deps
 
 ENTRYPOINT [ "bright-cli" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="NeuraLegion"
 LABEL org.opencontainers.image.title="Repeater"
 LABEL org.opencontainers.image.source="git@github.com:NeuraLegion/bright-cli.git"
 LABEL org.opencontainers.image.url="https://github.com/NeuraLegion/bright-cli"
-LABEL org.opencontainers.image.authors="Arten Derevnjuk <artem.derevnjuk@brightsec.com>"
+LABEL org.opencontainers.image.authors="Artem Derevnjuk <artem.derevnjuk@brightsec.com>"
 LABEL org.opencontainers.image.version="$VERSION"
 
 # a few environment variables to make NPM installs easier

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-alpine as base
 
 ARG VERSION
 
-LABEL org.opencontainers.image.vendor="NeuraLegion"
+LABEL org.opencontainers.image.vendor="Bright Security Inc."
 LABEL org.opencontainers.image.title="Repeater"
 LABEL org.opencontainers.image.source="git@github.com:NeuraLegion/bright-cli.git"
 LABEL org.opencontainers.image.url="https://github.com/NeuraLegion/bright-cli"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG VERSION
 
 LABEL org.opencontainers.image.vendor="NeuraLegion"
 LABEL org.opencontainers.image.title="Repeater"
-LABEL org.opencontainers.image.source="git@github.com:NeuraLegion/nexploit-cli.git"
-LABEL org.opencontainers.image.url="https://github.com/NeuraLegion/nexploit-cli"
+LABEL org.opencontainers.image.source="git@github.com:NeuraLegion/bright-cli.git"
+LABEL org.opencontainers.image.url="https://github.com/NeuraLegion/bright-cli"
 LABEL org.opencontainers.image.authors="Arten Derevnjuk <artem.derevnjuk@brightsec.com>"
 LABEL org.opencontainers.image.version="$VERSION"
 
@@ -23,8 +23,8 @@ RUN npm config -g set user $(whoami)
 
 #  add libraries needed to build os-service
 RUN apk add --no-cache --virtual .build-deps make gcc g++ python3 \
-    && npm i -g -q @neuralegion/nexploit-cli@${VERSION} \
+    && npm i -g -q @neuralegion/bright-cli@${VERSION} \
     && apk del .build-deps
 
-ENTRYPOINT [ "nexploit-cli" ]
+ENTRYPOINT [ "bright-cli" ]
 CMD ["repeater"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Bright Security Inc. All Rights Reserved
+Copyright (c) 2023 Bright Security Inc. All Rights Reserved
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bright CLI
 
-[Bright](https://brightsec.com) is a powerful dynamic application & API security testing (DAST) platform.With its effective automation and integration capabilities, Bright allows developers to scan multiple targets, uncover security vulnerabilities without false positives, get detailed reports on every finding, and quickly fix security issues by following the remediation guidelines.
+[Bright](https://brightsec.com) is a powerful dynamic application & API security testing (DAST) platform. With its effective automation and integration capabilities, Bright allows developers to scan multiple targets, uncover security vulnerabilities without false positives, get detailed reports on every finding, and quickly fix security issues by following the remediation guidelines.
 
 The NPM allows you to install the Bright Command Line Interface (CLI) on your machine. You can use the **Bright CLI** to run and manage security scans directly from your development environment. In addition, the container includes a preconfigured [Repeater (scan proxy)](https://docs.brightsec.com/docs/on-premises-repeater-local-agent), which enables you to scan local targets securely, without exposing them to the Internet.
 
@@ -10,7 +10,7 @@ The NPM allows you to install the Bright Command Line Interface (CLI) on your ma
 - [Repeater mode](https://docs.brightsec.com/docs/initializing-the-repeater), which allows the Bright cloud engine to connect to local targets securely, pulling all scan requests as outbound traffic, without exposing the targets to the Internet.
 - Flexible proxy configuration, which allows you to control the CLI requests both internally and externally.
 - Connector to on-premises (local) ticketing services. For example, you can enable the Bright integration with on-premises Jira, for tickets to be automatically opened for each security vulnerability detected.
-- Integration of Bright with your CI pipelines. Please see our (guide on integrating Bright with CI pipelines)[https://docs.neuralegion.com/docs/integrate-nexploit-with-your-ci-pipeline] for more information.
+- Integration of Bright with your CI pipelines. Please see our [guide on integrating Bright with CI pipelines](https://docs.neuralegion.com/docs/integrate-nexploit-with-your-ci-pipeline) for more information.
 - Running commands from a configuration file. You can run the CLI commands from your console or save them as a JSON, XML, YML, or JavaScript file. Running the CLI from a pre-configured file will simplify further scanning.
 
 ## 🔎 Table of Contents
@@ -41,7 +41,7 @@ You can make sure the installation worked by executing the following command:
 bright-cli --version
 ```
 
-It should return the latest Repeater version.
+It should return the latest Bright CLI version.
 
 #### 2. Activate the Repeater
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The NPM allows you to install the Bright Command Line Interface (CLI) on your ma
 - [Repeater mode](https://docs.brightsec.com/docs/initializing-the-repeater), which allows the Bright cloud engine to connect to local targets securely, pulling all scan requests as outbound traffic, without exposing the targets to the Internet.
 - Flexible proxy configuration, which allows you to control the CLI requests both internally and externally.
 - Connector to on-premises (local) ticketing services. For example, you can enable the Bright integration with on-premises Jira, for tickets to be automatically opened for each security vulnerability detected.
-- Integration of Bright with your CI pipelines. Please see our [guide on integrating Bright with CI pipelines](https://docs.neuralegion.com/docs/integrate-nexploit-with-your-ci-pipeline) for more information.
+- Integration of Bright with your CI pipelines. Please see our [guide on integrating Bright with CI pipelines](https://docs.brightsec.com/docs/integrate-bright-with-your-ci-pipeline) for more information.
 - Running commands from a configuration file. You can run the CLI commands from your console or save them as a JSON, XML, YML, or JavaScript file. Running the CLI from a pre-configured file will simplify further scanning.
 
 ## 🔎 Table of Contents
@@ -25,8 +25,8 @@ Before you can use **Bright CLI** make sure you have the following:
 
 - An active user in [the Bright app](https://app.brightsec.com/)
 - You have Docker installed on your machine.
-- You have a valid [organization API key](https://docs.neuralegion.com/docs/manage-your-organization#manage-organization-apicli-authentication-tokens) or a [personal API key](https://docs.neuralegion.com/docs/manage-your-personal-account#manage-your-personal-api-keys-authentication-tokens) with the following scopes: `bot`, `scans:run` and `scans:read`. You can watch video about [creating API keys](https://www.youtube.com/watch?v=W_WdIGPXoUQ&t=3s).
-- You have registered (created) a Repeater in the Bright app and copied the generated Repeater ID. For the instructions on how to register a Repeater, see [here](https://docs.neuralegion.com/docs/manage-repeaters#create-a-new-repeater).
+- You have a valid [organization API key](https://docs.brightsec.com/docs/manage-your-organization#manage-organization-apicli-authentication-tokens) or a [personal API key](https://docs.brightsec.com/docs/manage-your-personal-account#manage-your-personal-api-keys-authentication-tokens) with the following scopes: `bot`, `scans:run` and `scans:read`. You can watch video about [creating API keys](https://www.youtube.com/watch?v=W_WdIGPXoUQ&t=3s).
+- You have registered (created) a Repeater in the Bright app and copied the generated Repeater ID. For the instructions on how to register a Repeater, see [here](https://docs.brightsec.com/docs/manage-repeaters#create-a-new-repeater).
 - You have copied the Bright Project ID under which you want to run a scan. A Project ID is required. If you do not have any custom projects, use the Default Project ID.
 
 #### 1. Install Bright CLI globally
@@ -69,11 +69,11 @@ We recommend that you use the `--smart` option to optimize the scan coverage and
 
 #### 4. Check out the scan results
 
-You can follow the scan status in the [Bright app](https://app.neuralegion.com/scans) or by using the [**Bright CLI** polling](https://docs.neuralegion.com/docs/checking-scan-status) command.
+You can follow the scan status in the [Bright app](https://app.brightsec.com/scans) or by using the [**Bright CLI** polling](https://docs.brightsec.com/docs/checking-scan-status) command.
 
 ## 📚 Full Documentation
 
-The **Bright CLI** can do so much more! You can find a full guide with the usage examples in the [Bright docs](https://docs.neuralegion.com/docs/getting-started-with-nexploit-cli).
+The **Bright CLI** can do so much more! You can find a full guide with the usage examples in the [Bright docs](https://docs.brightsec.com/docs/getting-started-with-bright-cli).
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ The **Bright CLI** can do so much more! You can find a full guide with the usage
 
 ## 📝 License
 
-Copyright © 2022 Bright Security Inc.
+Copyright © 2023 [Bright Security Inc.](https://brightsec.com/)
 
 This project is licensed under the MIT License - see the [LICENSE file](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NexPloit CLI
+# Bright CLI
 
-**NexPloit CLI** is a Command Line Interface ([CLI](https://en.wikipedia.org/wiki/Command-line_interface)) tool for [Bright's solutions](https://www.brightsec.com). You can use **NexPloit CLI** for full control over scans such as: initialize, stop, poll, maintain and more. In addition, **NexPloit CLI** can serve as a [Repeater](https://docs.brightsec.com/docs/on-premises-repeater-local-agent) to scan local targets, without exposing them to the internet.
+**Bright CLI** is a Command Line Interface ([CLI](https://en.wikipedia.org/wiki/Command-line_interface)) tool for [Bright's solutions](https://www.brightsec.com). You can use **Bright CLI** for full control over scans such as: initialize, stop, poll, maintain and more. In addition, **Bright CLI** can serve as a [Repeater](https://docs.brightsec.com/docs/on-premises-repeater-local-agent) to scan local targets, without exposing them to the internet.
 
 ##### Features:
 
@@ -17,7 +17,7 @@
 
 ## 🚀 Quick Start
 
-Before you can use **NexPloit CLI** make sure you have the following:
+Before you can use **Bright CLI** make sure you have the following:
 
 - An active user in [the Bright app](https://app.brightsec.com/)
 - A valid `TOKEN`
@@ -26,24 +26,24 @@ Before you can use **NexPloit CLI** make sure you have the following:
 - An active `ID`
   - More info about [Setting up a New Repeater](https://docs.brightsec.com/docs/manage-repeaters)
 
-#### 1. Install NexPloit CLI globally
+#### 1. Install Bright CLI globally
 
 ```bash
-npm install @neuralegion/nexploit-cli -g
+npm install @neuralegion/bright-cli -g
 ```
 
 You can validate the installation by going to the directory of your project and running the command:
 
 ```bash
-nexploit-cli -h
+bright-cli -h
 ```
 
-This will show you a list of possible commands for NexPloit CLI, for a full list go [here](https://docs.brightsec.com/docs/command-list)
+This will show you a list of possible commands for Bright CLI, for a full list go [here](https://docs.brightsec.com/docs/command-list)
 
 #### 2. Activate the Repeater
 
 ```bash
-nexploit-cli repeater \
+bright-cli repeater \
   --token {TOKEN} \
   --id {ID} \
   --bus amqps://amq.app.brightsec.com:5672
@@ -52,7 +52,7 @@ nexploit-cli repeater \
 #### 3. Start a new scan with a Crawler
 
 ```bash
-nexploit-cli scan:run \
+bright-cli scan:run \
   --token {TOKEN} \
   --repeater {ID} \
   --name "My First Scan" \
@@ -64,11 +64,11 @@ This command will initialize a new scan engine in the cloud, which will start sc
 
 #### 4. Check out the scan results
 
-You can follow the scan status here: https://app.brightsec.com/scans, or by using the [NexPloit CLI polling](https://docs.brightsec.com/docs/checking-scan-status) command.
+You can follow the scan status here: https://app.brightsec.com/scans, or by using the [Bright CLI polling](https://docs.brightsec.com/docs/checking-scan-status) command.
 
 ## 📚 Full Documentation
 
-**NexPloit CLI** can do so much more! A full documentation with usage examples is available on [Bright's knowledgebase](https://docs.brightsec.com)
+**Bright CLI** can do so much more! A full documentation with usage examples is available on [Bright's knowledgebase](https://docs.brightsec.com)
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Bright CLI
 
-**Bright CLI** is a Command Line Interface ([CLI](https://en.wikipedia.org/wiki/Command-line_interface)) tool for [Bright's solutions](https://www.brightsec.com). You can use **Bright CLI** for full control over scans such as: initialize, stop, poll, maintain and more. In addition, **Bright CLI** can serve as a [Repeater](https://docs.brightsec.com/docs/on-premises-repeater-local-agent) to scan local targets, without exposing them to the internet.
+[Bright](https://brightsec.com) is a powerful dynamic application & API security testing (DAST) platform.With its effective automation and integration capabilities, Bright allows developers to scan multiple targets, uncover security vulnerabilities without false positives, get detailed reports on every finding, and quickly fix security issues by following the remediation guidelines.
+
+The NPM allows you to install the Bright Command Line Interface (CLI) on your machine. You can use the **Bright CLI** to run and manage security scans directly from your development environment. In addition, the container includes a preconfigured [Repeater (scan proxy)](https://docs.brightsec.com/docs/on-premises-repeater-local-agent), which enables you to scan local targets securely, without exposing them to the Internet.
 
 ##### Features:
 
-- Supports official API
-- Configurable using JSON / XML / YML / JS formats
-- Can generate real interaction data (.har files) from mock interactions (Unit Tests), more info about NexMock [here](https://www.npmjs.com/package/@neuralegion/nexmock)
-- Can serve as a [Repeater](https://docs.brightsec.com/docs/on-premises-repeater-local-agent) for communication from the cloud to a local target
+- Easy control of the Bright REST API.
+- [Repeater mode](https://docs.brightsec.com/docs/initializing-the-repeater), which allows the Bright cloud engine to connect to local targets securely, pulling all scan requests as outbound traffic, without exposing the targets to the Internet.
+- Flexible proxy configuration, which allows you to control the CLI requests both internally and externally.
+- Connector to on-premises (local) ticketing services. For example, you can enable the Bright integration with on-premises Jira, for tickets to be automatically opened for each security vulnerability detected.
+- Integration of Bright with your CI pipelines. Please see our (guide on integrating Bright with CI pipelines)[https://docs.neuralegion.com/docs/integrate-nexploit-with-your-ci-pipeline] for more information.
+- Running commands from a configuration file. You can run the CLI commands from your console or save them as a JSON, XML, YML, or JavaScript file. Running the CLI from a pre-configured file will simplify further scanning.
 
 ## 🔎 Table of Contents
 
 - [Quick Start](#🚀-quick-start)
-- [Documentation](#📚-full-documentation)
+- [Full Documentation](#📚-full-documentation)
 - [License](#📝-license)
 
 ## 🚀 Quick Start
@@ -20,11 +24,10 @@
 Before you can use **Bright CLI** make sure you have the following:
 
 - An active user in [the Bright app](https://app.brightsec.com/)
-- A valid `TOKEN`
-  - For the quick start these scopes are required: `bot`, `scans:run` and `scans:read`
-  - More info about [setting up an API key](https://docs.brightsec.com/docs/manage-your-organization#manage-organization-apicli-authentication-tokens)
-- An active `ID`
-  - More info about [Setting up a New Repeater](https://docs.brightsec.com/docs/manage-repeaters)
+- You have Docker installed on your machine.
+- You have a valid [organization API key](https://docs.neuralegion.com/docs/manage-your-organization#manage-organization-apicli-authentication-tokens) or a [personal API key](https://docs.neuralegion.com/docs/manage-your-personal-account#manage-your-personal-api-keys-authentication-tokens) with the following scopes: `bot`, `scans:run` and `scans:read`. You can watch video about [creating API keys](https://www.youtube.com/watch?v=W_WdIGPXoUQ&t=3s).
+- You have registered (created) a Repeater in the Bright app and copied the generated Repeater ID. For the instructions on how to register a Repeater, see [here](https://docs.neuralegion.com/docs/manage-repeaters#create-a-new-repeater).
+- You have copied the Bright Project ID under which you want to run a scan. A Project ID is required. If you do not have any custom projects, use the Default Project ID.
 
 #### 1. Install Bright CLI globally
 
@@ -32,21 +35,20 @@ Before you can use **Bright CLI** make sure you have the following:
 npm install @brightsec/cli -g
 ```
 
-You can validate the installation by going to the directory of your project and running the command:
+You can make sure the installation worked by executing the following command:
 
 ```bash
-bright-cli -h
+bright-cli --version
 ```
 
-This will show you a list of possible commands for Bright CLI, for a full list go [here](https://docs.brightsec.com/docs/command-list)
+It should return the latest Repeater version.
 
 #### 2. Activate the Repeater
 
 ```bash
 bright-cli repeater \
   --token {TOKEN} \
-  --id {ID} \
-  --bus amqps://amq.app.brightsec.com:5672
+  --id {ID}
 ```
 
 #### 3. Start a new scan with a Crawler
@@ -55,23 +57,26 @@ bright-cli repeater \
 bright-cli scan:run \
   --token {TOKEN} \
   --repeater {ID} \
-  --name "My First Scan" \
-  --crawler https://www.example.com \
+  --name "Bright scan" \
+  --crawler {TARGET_URL} \
+  --project {PROJECT_ID}  \ #If you do not have any custom projects, specify the Default Project ID.
   --smart
 ```
 
-This command will initialize a new scan engine in the cloud, which will start scanning the target via the local [Repeater](https://docs.brightsec.com/docs/on-premises-repeater-local-agent).
+This command will initialize a new scan engine on the cloud, which will start scanning the target in the Repeater mode.
+
+We recommend that you use the `--smart` option to optimize the scan coverage and time. This enables you to use automatic smart decisions, such as parameter skipping, detection phases and so on.
 
 #### 4. Check out the scan results
 
-You can follow the scan status here: https://app.brightsec.com/scans, or by using the [Bright CLI polling](https://docs.brightsec.com/docs/checking-scan-status) command.
+You can follow the scan status in the [Bright app](https://app.neuralegion.com/scans) or by using the [**Bright CLI** polling](https://docs.neuralegion.com/docs/checking-scan-status) command.
 
 ## 📚 Full Documentation
 
-**Bright CLI** can do so much more! A full documentation with usage examples is available on [Bright's knowledgebase](https://docs.brightsec.com)
+The **Bright CLI** can do so much more! You can find a full guide with the usage examples in the [Bright docs](https://docs.neuralegion.com/docs/getting-started-with-nexploit-cli).
 
 ## 📝 License
 
-Copyright © 2021 [Bright](https://github.com/NeuraLegion).
+Copyright © 2022 Bright Security Inc.
 
 This project is licensed under the MIT License - see the [LICENSE file](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you can use **Bright CLI** make sure you have the following:
 #### 1. Install Bright CLI globally
 
 ```bash
-npm install @neuralegion/bright-cli -g
+npm install @brightsec/cli -g
 ```
 
 You can validate the installation by going to the directory of your project and running the command:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neuralegion/bright-cli",
+  "name": "@brightsec/cli",
   "version": "8.11.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neuralegion/nexploit-cli",
+  "name": "@neuralegion/bright-cli",
   "version": "8.11.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightsec/cli",
-  "version": "8.11.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neuralegion/bright-cli",
+  "name": "@brightsec/cli",
   "version": "8.11.0",
   "private": false,
   "repository": {
@@ -100,6 +100,7 @@
     "cli",
     "api",
     "nexploit-cli",
+    "brightsec-cli",
     "bright-cli",
     "cyber-security",
     "security",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ws": "~8.1.0",
     "yargs": "~16.2.0"
   },
-  "description": "Bright CLI is a CLI tool that can initialize, stop, polling and maintain scans in NeuraLegions solutions (Such as Bright).",
+  "description": "Bright CLI is a CLI tool that can initialize, stop, polling and maintain scans in Bright solutions.",
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
@@ -99,7 +99,6 @@
     "nexploit",
     "cli",
     "api",
-    "nexploit",
     "bright",
     "cyber-security",
     "security",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightsec/cli",
-  "version": "8.11.0",
+  "version": "0.0.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -99,9 +99,8 @@
     "nexploit",
     "cli",
     "api",
-    "nexploit-cli",
-    "brightsec-cli",
-    "bright-cli",
+    "nexploit",
+    "bright",
     "cyber-security",
     "security",
     "har",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@neuralegion/nexploit-cli",
+  "name": "@neuralegion/bright-cli",
   "version": "8.11.0",
   "private": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NeuraLegion/nexploit-cli.git"
+    "url": "git+https://github.com/NeuraLegion/bright-cli.git"
   },
   "author": "Artem Derevnjuk <artem.derevnjuk@brightsec.com>",
   "bin": {
-    "nexploit-cli": "./dist/index.js"
+    "bright-cli": "./dist/index.js"
   },
   "bugs": {
-    "url": "https://github.com/NeuraLegion/nexploit-cli/issues"
+    "url": "https://github.com/NeuraLegion/bright-cli/issues"
   },
   "commitlint": {
     "extends": [
@@ -45,7 +45,7 @@
     "ws": "~8.1.0",
     "yargs": "~16.2.0"
   },
-  "description": "NexPloit CLI is a CLI tool that can initialize, stop, polling and maintain scans in NeuraLegions solutions (Such as NexPloit).",
+  "description": "Bright CLI is a CLI tool that can initialize, stop, polling and maintain scans in NeuraLegions solutions (Such as Bright).",
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
@@ -94,12 +94,13 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/NeuraLegion/nexploit-cli#readme",
+  "homepage": "https://github.com/NeuraLegion/bright-cli#readme",
   "keywords": [
     "nexploit",
     "cli",
     "api",
     "nexploit-cli",
+    "bright-cli",
     "cyber-security",
     "security",
     "har",

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -36,12 +36,6 @@ export class Configure implements CommandModule {
         requiresArg: true,
         describe: `Bright event message authentication endpoint`
       })
-      .option('nogui', {
-        default: true,
-        deprecated: true,
-        boolean: true,
-        describe: `Start a configuration wizard without GUI`
-      })
       .option('ping', {
         boolean: true,
         describe: `Start network tests.`

--- a/src/Commands/Integration.ts
+++ b/src/Commands/Integration.ts
@@ -20,7 +20,7 @@ import Timer = NodeJS.Timer;
 let timer: Timer;
 
 export class Integration implements CommandModule {
-  private static SERVICE_NAME = 'nexploit-integration';
+  private static SERVICE_NAME = 'bright-integration';
   public readonly command = 'integration [options]';
   public readonly describe = 'Starts an on-prem integration.';
 
@@ -134,7 +134,7 @@ export class Integration implements CommandModule {
         command,
         args: execArgs,
         name: Integration.SERVICE_NAME,
-        displayName: 'NexPloit Integration'
+        displayName: 'Bright Integration'
       });
 
       logger.log(

--- a/src/Commands/VersionCommand.ts
+++ b/src/Commands/VersionCommand.ts
@@ -34,7 +34,7 @@ export class VersionCommand implements CommandModule {
       'npm list --depth=0'
     );
     const localMatches: RegExpMatchArray | null = localNpmList.match(
-      / @neuralegion\/bright-cli@(.*)\n/
+      / @brightsec\/cli@(.*)\n/
     );
     const localNpmVersion: string = (
       localMatches && localMatches[1] ? localMatches[1] : ''
@@ -46,7 +46,7 @@ export class VersionCommand implements CommandModule {
       'npm list -g --depth=0'
     );
     const globalMatches: RegExpMatchArray | null = globalNpmList.match(
-      / @neuralegion\/bright-cli@(.*)\n/
+      / @brightsec\/cli@(.*)\n/
     );
     const globalNpmVersion: string = (
       globalMatches && globalMatches[1] ? globalMatches[1] : ''

--- a/src/Config/CliBuilder.ts
+++ b/src/Config/CliBuilder.ts
@@ -67,7 +67,7 @@ export class CliBuilder {
         ({ bus: args.bus, api: args.api } = Helpers.getClusterUrls(
           args as ClusterArgs
         ));
-      }, true)
+      })
       // TODO: (victor.polyakov@brightsec.com) Write correct type checking
       .middleware(
         (args: Arguments) =>

--- a/src/Config/CliBuilder.ts
+++ b/src/Config/CliBuilder.ts
@@ -90,7 +90,7 @@ export class CliBuilder {
             : LogLevel[args.logLevel.toString().toUpperCase()])
       )
       .usage('Usage: $0 <command> [options] [<file | scan>]')
-      .pkgConf('nexploit', info.cwd)
+      .pkgConf('bright', info.cwd)
       .example(
         '$0 archive:generate --mockfile=.mockfile --name=archive.har',
         'output har file on base your mock requests'

--- a/src/Config/CliBuilder.ts
+++ b/src/Config/CliBuilder.ts
@@ -40,20 +40,6 @@ export class CliBuilder {
         describe:
           'What level of logs to report. Any logs of a higher level than the setting are shown.'
       })
-      .option('api', {
-        requiresArg: true,
-        demandOption: true,
-        deprecated: true,
-        describe:
-          'Bright application base URL. [default: https://app.brightsec.com]'
-      })
-      .option('bus', {
-        requiresArg: true,
-        demandOption: true,
-        deprecated: true,
-        describe:
-          'Bright Event Bus base URL. [default: amqps://amq.app.brightsec.com:5672]'
-      })
       .option('cluster', {
         requiresArg: true,
         describe:

--- a/src/Config/CliInfo.ts
+++ b/src/Config/CliInfo.ts
@@ -26,7 +26,7 @@ export class CliInfo {
 
   private getPkgPath(cwd?: string): string {
     return sync('package.json', {
-      cwd: cwd || process.env.NEXPLOIT_CWD || process.cwd()
+      cwd: cwd || process.env.BRIGHT_CWD || process.cwd()
     });
   }
 }

--- a/src/Config/DefaultConfigReader.ts
+++ b/src/Config/DefaultConfigReader.ts
@@ -1,5 +1,5 @@
 import { CliConfig, ConfigReader } from './ConfigReader';
-import { Helpers } from '../Utils/Helpers';
+import { Helpers } from '../Utils';
 import { sync } from 'find-up';
 import { load } from 'js-yaml';
 import { extname } from 'path';
@@ -8,6 +8,12 @@ import { Context, createContext, Script } from 'vm';
 
 export class DefaultConfigReader implements ConfigReader {
   private readonly rcOptions: string[] = [
+    '.brightrc',
+    '.brightrc.json',
+    '.brightrc.yml',
+    '.brightrc.yaml',
+    'bright.config.js',
+    //backward compatibility with legacy nexploit-cli
     '.nexploitrc',
     '.nexploitrc.json',
     '.nexploitrc.yml',

--- a/src/Config/DefaultConfigReader.ts
+++ b/src/Config/DefaultConfigReader.ts
@@ -13,7 +13,7 @@ export class DefaultConfigReader implements ConfigReader {
     '.brightrc.yml',
     '.brightrc.yaml',
     'bright.config.js',
-    //backward compatibility with legacy nexploit-cli
+    // ADHOC: keep for backward compatibility with the legacy nexploit-cli.
     '.nexploitrc',
     '.nexploitrc.json',
     '.nexploitrc.yml',

--- a/src/Repeater/DefaultRepeaterLauncher.ts
+++ b/src/Repeater/DefaultRepeaterLauncher.ts
@@ -21,7 +21,7 @@ import Timer = NodeJS.Timer;
 
 @injectable()
 export class DefaultRepeaterLauncher implements RepeaterLauncher {
-  private static SERVICE_NAME = 'nexploit-repeater';
+  private static SERVICE_NAME = 'bright-repeater';
   private timer: Timer | undefined;
   private repeaterId: string | undefined;
   private repeaterStarted: boolean = false;
@@ -68,7 +68,7 @@ export class DefaultRepeaterLauncher implements RepeaterLauncher {
       command,
       args: execArgs,
       name: DefaultRepeaterLauncher.SERVICE_NAME,
-      displayName: 'NexPloit Repeater'
+      displayName: 'Bright Repeater'
     });
 
     logger.log(

--- a/src/Scan/Breakpoints/OnAny.ts
+++ b/src/Scan/Breakpoints/OnAny.ts
@@ -8,7 +8,7 @@ export class OnAny extends Breakpoint {
   }
 
   protected breakOn(): never {
-    throw new BreakpointException(`NexPloit CLI found a first issue.`);
+    throw new BreakpointException('Bright CLI found a first issue.');
   }
 
   protected selectCriterion(

--- a/src/Scan/Breakpoints/OnSeverity.ts
+++ b/src/Scan/Breakpoints/OnSeverity.ts
@@ -9,7 +9,7 @@ export class OnSeverity extends Breakpoint {
 
   protected breakOn(): never {
     throw new BreakpointException(
-      `NexPloit CLI found a first ${this.severity} issue.`
+      `Bright CLI found a first ${this.severity} issue.`
     );
   }
 

--- a/src/Utils/Helpers.spec.ts
+++ b/src/Utils/Helpers.spec.ts
@@ -8,34 +8,6 @@ enum TestEnum {
 
 describe('Helpers', () => {
   describe('getClusterUrls', () => {
-    it('should throw error when --cluster and --bus used', () => {
-      // arrange
-      const args = {
-        bus: 'amqps://localhost:5672',
-        cluster: 'localhost'
-      };
-      // act
-      const act = () => Helpers.getClusterUrls(args);
-      // assert
-      expect(act).toThrow(
-        'Arguments api/bus and cluster are mutually exclusive'
-      );
-    });
-
-    it('should throw error when --cluster and --api used', () => {
-      // arrange
-      const args = {
-        api: 'http://localhost:8000',
-        cluster: 'localhost'
-      };
-      // act
-      const act = () => Helpers.getClusterUrls(args);
-      // assert
-      expect(act).toThrow(
-        'Arguments api/bus and cluster are mutually exclusive'
-      );
-    });
-
     it('should returns localhost api and bus if --cluster is localhost', () => {
       // arrange
       const args = {
@@ -74,21 +46,6 @@ describe('Helpers', () => {
       expect(result).toEqual({
         api: 'https://test.com',
         bus: 'amqps://amq.test.com:5672'
-      });
-    });
-
-    it('should returns values with --api and --bus option', () => {
-      // arrange
-      const args = {
-        api: 'https://test.com',
-        bus: 'amqps://rabbit.test.com'
-      };
-      // act
-      const result = Helpers.getClusterUrls(args);
-      // assert
-      expect(result).toEqual({
-        api: 'https://test.com',
-        bus: 'amqps://rabbit.test.com'
       });
     });
   });

--- a/src/Utils/Helpers.ts
+++ b/src/Utils/Helpers.ts
@@ -22,8 +22,6 @@ export interface CommandArgs {
 }
 
 export interface ClusterArgs {
-  api?: string;
-  bus?: string;
   cluster?: string;
 }
 
@@ -55,9 +53,6 @@ export class Helpers {
     let api: string;
 
     if (args.cluster) {
-      if (args.api || args.bus) {
-        throw new Error('Arguments api/bus and cluster are mutually exclusive');
-      }
       let host = args.cluster;
 
       try {
@@ -74,8 +69,8 @@ export class Helpers {
         api = `https://${host}`;
       }
     } else {
-      api = (args.api as string) ?? `https://app.brightsec.com`;
-      bus = (args.bus as string) ?? `amqps://amq.app.brightsec.com:5672`;
+      api = 'https://app.brightsec.com';
+      bus = 'amqps://amq.app.brightsec.com:5672';
     }
 
     return { api, bus };

--- a/src/Wizard/FSTokens.ts
+++ b/src/Wizard/FSTokens.ts
@@ -6,6 +6,14 @@ import { homedir } from 'os';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+/**
+ * @deprecated .nexploit-cli path is deprecated, use .bright-cli.
+ * Now it's handled for backward compatibility.
+ */
+const LEGACY_TOKENS_STORAGE_BASE_DIR = '.nexploit-cli';
+
+const TOKENS_STORAGE_BASE_DIR = '.bright-cli';
+
 @injectable()
 export class FSTokens implements Tokens {
   private readonly baseDir: string = homedir();
@@ -18,18 +26,33 @@ export class FSTokens implements Tokens {
 
   public readTokens(): Credentials | undefined {
     logger.debug('Reading saved tokens from file %s', this.path);
-
-    if (existsSync(this.path)) {
-      logger.debug('File found. Returns the tokens.');
-      const result: Buffer = readFileSync(this.path);
-
-      return JSON.parse(result.toString('utf8')) as Credentials;
+    let result: Credentials;
+    for (const path of this.paths) {
+      if (existsSync(path)) {
+        logger.debug('File found. Returns the tokens.');
+        const resultRaw: Buffer = readFileSync(this.path);
+        const fileResult = JSON.parse(
+          resultRaw.toString('utf8')
+        ) as Credentials;
+        result = Object.assign(result ?? {}, fileResult);
+      }
     }
 
-    logger.debug("File doesn't exist.");
+    if (!result) {
+      logger.debug("File doesn't exist.");
+    }
+
+    return result;
+  }
+
+  private get paths(): string[] {
+    return [
+      join(this.baseDir, LEGACY_TOKENS_STORAGE_BASE_DIR),
+      join(this.baseDir, TOKENS_STORAGE_BASE_DIR)
+    ];
   }
 
   private get path(): string {
-    return join(this.baseDir, '.nexploit-cli');
+    return join(this.baseDir, TOKENS_STORAGE_BASE_DIR);
   }
 }

--- a/src/Wizard/FSTokens.ts
+++ b/src/Wizard/FSTokens.ts
@@ -40,6 +40,6 @@ export class FSTokens implements Tokens {
    * @deprecated `.nexploit-cli` path is deprecated, use .bright-cli. It's handled for backward compatibility.
    */
   private get legacyPath(): string {
-    return join(this.baseDir, '.bright-cli');
+    return join(this.baseDir, '.nexploit-cli');
   }
 }

--- a/src/Wizard/FSTokens.ts
+++ b/src/Wizard/FSTokens.ts
@@ -6,14 +6,6 @@ import { homedir } from 'os';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
-/**
- * @deprecated .nexploit-cli path is deprecated, use .bright-cli.
- * Now it's handled for backward compatibility.
- */
-const LEGACY_TOKENS_STORAGE_BASE_DIR = '.nexploit-cli';
-
-const TOKENS_STORAGE_BASE_DIR = '.bright-cli';
-
 @injectable()
 export class FSTokens implements Tokens {
   private readonly baseDir: string = homedir();
@@ -25,34 +17,29 @@ export class FSTokens implements Tokens {
   }
 
   public readTokens(): Credentials | undefined {
-    logger.debug('Reading saved tokens from file %s', this.path);
     let result: Credentials;
-    for (const path of this.paths) {
+    for (const path of [this.path, this.legacyPath]) {
+      logger.debug('Reading saved tokens from file %s', path);
       if (existsSync(path)) {
-        logger.debug('File found. Returns the tokens.');
-        const resultRaw: Buffer = readFileSync(this.path);
-        const fileResult = JSON.parse(
-          resultRaw.toString('utf8')
-        ) as Credentials;
-        result = Object.assign(result ?? {}, fileResult);
+        logger.debug('File found. Return the tokens.');
+        const resultRaw: Buffer = readFileSync(path);
+
+        return JSON.parse(resultRaw.toString('utf8')) as Credentials;
       }
     }
-
     if (!result) {
       logger.debug("File doesn't exist.");
     }
-
-    return result;
-  }
-
-  private get paths(): string[] {
-    return [
-      join(this.baseDir, LEGACY_TOKENS_STORAGE_BASE_DIR),
-      join(this.baseDir, TOKENS_STORAGE_BASE_DIR)
-    ];
   }
 
   private get path(): string {
-    return join(this.baseDir, TOKENS_STORAGE_BASE_DIR);
+    return join(this.baseDir, '.bright-cli');
+  }
+
+  /**
+   * @deprecated `.nexploit-cli` path is deprecated, use .bright-cli. It's handled for backward compatibility.
+   */
+  private get legacyPath(): string {
+    return join(this.baseDir, '.bright-cli');
   }
 }

--- a/tests/Commands/version.spec.ts
+++ b/tests/Commands/version.spec.ts
@@ -19,7 +19,7 @@ describe('"version" command', () => {
     async () => {
       const actual = await cli.spawn('version');
       expect(actual).toEqual(
-        expect.stringContaining('No local installed NexPloit CLI was found.')
+        expect.stringContaining('No local installed Bright CLI was found.')
       );
       expect(actual).toEqual(
         expect.stringContaining('No global installed was found.')

--- a/tools/msi/LICENSE.rtf
+++ b/tools/msi/LICENSE.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi{\fonttbl\f0\fswiss Helvetica;}\f0\pard
 MIT License \par
 \par
-Copyright (c) 2022 Bright Security Inc. All Rights Reserved \par
+Copyright (c) 2023 Bright Security Inc. All Rights Reserved \par
 \par
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tools/msi/build.ps1
+++ b/tools/msi/build.ps1
@@ -10,7 +10,7 @@ $VERSION = $VERSION -replace '([A-Za-z-.])+','.'
 $WIX_DIR="c:\Program Files (x86)\WiX Toolset v3.11\bin"
 
 . "$WIX_DIR\candle.exe" -arch x64 -dProductVersion="$VERSION" -dSourceDir="$OUTPUT_DIR" -dRepoDir="." $INSTALLER_DIR\product.wxs -o $OUTPUT_DIR\ -ext WixUtilExtension  -ext WixUIExtension
-. "$WIX_DIR\light.exe" -o $OUTPUT_DIR\nexploit-cli.msi $OUTPUT_DIR\*.wixobj -ext WixUtilExtension  -ext WixUIExtension
+. "$WIX_DIR\light.exe" -o $OUTPUT_DIR\bright-cli.msi $OUTPUT_DIR\*.wixobj -ext WixUtilExtension  -ext WixUIExtension
 
 # optional digital sign the certificate.
 # you have to previously import it.

--- a/tools/msi/product.wxs
+++ b/tools/msi/product.wxs
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <?define ProductName="NexPloit CLI" ?>
+  <?define ProductName="Bright CLI" ?>
   <?define ProductAuthor="Bright Security Inc." ?>
   <?define ProductDescription="$(var.ProductName) is a CLI tool that can initialize, stop, polling and maintain scans in $(var.ProductAuthor)s solutions (Such as NexPloit)." ?>
   <?define RegistryKeyPath="SOFTWARE\$(var.ProductName)" ?>
   <Product Id="*" Name="$(var.ProductName)" UpgradeCode="74b15b74-a063-4524-ae83-69ad421be456" Language="1033" Codepage="1252" Version="$(var.ProductVersion)" Manufacturer="$(var.ProductAuthor)">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
     <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
-    <Property Id="ARPPRODUCTICON" Value="NexPloitIcon" />
-    <Property Id="ApplicationFolderName" Value="nexploit-cli" />
+    <Property Id="ARPPRODUCTICON" Value="BrightIcon" />
+    <Property Id="ApplicationFolderName" Value="bright-cli" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
     <Property Id="INSTALLDIR" Secure="yes">
       <RegistrySearch Id="InstallPathRegistry" Type="raw" Root="HKLM" Key="$(var.RegistryKeyPath)" Name="InstallPath" />
@@ -22,7 +22,7 @@
     <InstallExecuteSequence>
       <RemoveExistingProducts After="InstallValidate" />
     </InstallExecuteSequence>
-    <Icon Id="NexPloitIcon" SourceFile="$(var.RepoDir)\tools\resources\logo.ico" />
+    <Icon Id="BrightIcon" SourceFile="$(var.RepoDir)\tools\resources\logo.ico" />
     <Icon Id="WixUIInfoIco" SourceFile="$(var.RepoDir)\tools\resources\logo.ico" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramMenuFolder">
@@ -31,18 +31,18 @@
             <!-- RegistryValue needed because every Component must have a KeyPath.
                                             Because of ICE43, the Root must be HKCU. -->
             <RegistryValue Root="HKCU" Key="$(var.RegistryKeyPath)\Components" Type="integer" Value="1" KeyPath="yes" />
-            <util:InternetShortcut Id="OnlineWebsiteShortcut" Name="$(var.ProductName) repository" Target="https://github.com/NeuraLegion/nexploit-cli" Type="url" />
-            <util:InternetShortcut Id="OnlineDocumentationShortcut" Name="$(var.ProductName) documentation" Target="https://docs.brightsec.com/docs/about-nexploit-cli" Type="url" />
+            <util:InternetShortcut Id="OnlineWebsiteShortcut" Name="$(var.ProductName) repository" Target="https://github.com/NeuraLegion/bright-cli" Type="url" />
+            <util:InternetShortcut Id="OnlineDocumentationShortcut" Name="$(var.ProductName) documentation" Target="https://docs.brightsec.com/docs/about-bright-cli" Type="url" />
             <Shortcut Id="UninstallProduct" Name="Uninstall $(var.ProductName)" Target="[System64Folder]msiexec.exe" Arguments="/x [ProductCode]" />
-            <Shortcut Id="ExeShortcut" Name="$(var.ProductName)" Icon="NexPloitIcon" Target="[INSTALLDIR]nexploit-cli.exe" WorkingDirectory="INSTALLDIR" IconIndex="0" />
+            <Shortcut Id="ExeShortcut" Name="$(var.ProductName)" Icon="BrightIcon" Target="[INSTALLDIR]bright-cli.exe" WorkingDirectory="INSTALLDIR" IconIndex="0" />
             <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
           </Component>
         </Directory>
       </Directory>
       <Directory Id="ProgramFiles64Folder" Name="PFiles">
-        <Directory Id="INSTALLDIR" Name="NexPloitCLI">
+        <Directory Id="INSTALLDIR" Name="BrightCLI">
           <Component Id="Executable" Guid="8363278e-56cf-47c1-ba33-77eeaacb2baf" DiskId="1">
-            <File Id="nexploitcli.exe" Name="nexploit-cli.exe" KeyPath="yes" Source="$(var.SourceDir)\nexploit-cli.exe" Checksum="yes" />
+            <File Id="nexploitcli.exe" Name="bright-cli.exe" KeyPath="yes" Source="$(var.SourceDir)\bright-cli.exe" Checksum="yes" />
             <File Id="service.node" Name="service.node" Source="$(var.SourceDir)\service.node" Checksum="yes" />
             <File Id="raw.node" Name="raw.node" Source="$(var.SourceDir)\raw.node" Checksum="yes" />
             <File Id="roots.exe" Name="roots.exe" Source="$(var.SourceDir)\roots.exe" Checksum="yes" />
@@ -67,7 +67,7 @@
         </Directory>
       </Directory>
     </Directory>
-    <Feature Id="NexPloitRuntime" Level="1" Absent="disallow" Title="$(var.ProductName)" ConfigurableDirectory="INSTALLDIR" Description="Install $(var.ProductName) (nexploit-cli.exe).">
+    <Feature Id="BrightRuntime" Level="1" Absent="disallow" Title="$(var.ProductName)" ConfigurableDirectory="INSTALLDIR" Description="Install $(var.ProductName) (bright-cli.exe).">
       <ComponentRef Id="RegistryEntries" />
       <ComponentRef Id="EnvironmentPath" />
       <ComponentRef Id="Executable" />
@@ -115,7 +115,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
       <Property Id="ARPNOMODIFY" Value="1" />
-      <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="$(var.ProductName) has been succesfully installed. To run $(var.ProductName) open command prompt (cmd.exe), and run 'nexploit-cli'." />
+      <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="$(var.ProductName) has been succesfully installed. To run $(var.ProductName) open command prompt (cmd.exe), and run 'bright-cli'." />
     </UI>
     <UIRef Id="InstallUI" />
   </Product>

--- a/tools/msi/product.wxs
+++ b/tools/msi/product.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <?define ProductName="Bright CLI" ?>
   <?define ProductAuthor="Bright Security Inc." ?>
-  <?define ProductDescription="$(var.ProductName) is a CLI tool that can initialize, stop, polling and maintain scans in $(var.ProductAuthor)s solutions (Such as NexPloit)." ?>
+  <?define ProductDescription="$(var.ProductName) is a CLI tool that can initialize, stop, polling and maintain scans in $(var.ProductAuthor)s solutions (Such as Bright)." ?>
   <?define RegistryKeyPath="SOFTWARE\$(var.ProductName)" ?>
   <Product Id="*" Name="$(var.ProductName)" UpgradeCode="74b15b74-a063-4524-ae83-69ad421be456" Language="1033" Codepage="1252" Version="$(var.ProductVersion)" Manufacturer="$(var.ProductAuthor)">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
@@ -14,14 +14,8 @@
       <RegistrySearch Id="InstallPathRegistry" Type="raw" Root="HKLM" Key="$(var.RegistryKeyPath)" Name="InstallPath" />
       <RegistrySearch Id="InstallPathRegistryCU" Type="raw" Root="HKCU" Key="$(var.RegistryKeyPath)" Name="InstallPath" />
     </Property>
-    <Media Id="1" Cabinet="nexploitcli.cab" EmbedCab="yes" />
-    <CustomAction Id="NewVersionError" Error="A later version of $(var.ProductName) is already installed. Setup will now exit." />
-    <Upgrade Id="74b15b74-a063-4524-ae83-69ad421be456">
-      <UpgradeVersion Property="PREVIOUSVERSIONSINSTALLED" IncludeMinimum="no" IncludeMaximum="yes" Minimum="0.0.0" Maximum="$(var.ProductVersion)" />
-    </Upgrade>
-    <InstallExecuteSequence>
-      <RemoveExistingProducts After="InstallValidate" />
-    </InstallExecuteSequence>
+    <Media Id="1" Cabinet="brightcli.cab" EmbedCab="yes" />
+    <MajorUpgrade DowngradeErrorMessage="A later version of $(var.ProductName) is already installed. Setup will now exit." Schedule="afterInstallExecute" />
     <Icon Id="BrightIcon" SourceFile="$(var.RepoDir)\tools\resources\logo.ico" />
     <Icon Id="WixUIInfoIco" SourceFile="$(var.RepoDir)\tools\resources\logo.ico" />
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -42,7 +36,7 @@
       <Directory Id="ProgramFiles64Folder" Name="PFiles">
         <Directory Id="INSTALLDIR" Name="BrightCLI">
           <Component Id="Executable" Guid="8363278e-56cf-47c1-ba33-77eeaacb2baf" DiskId="1">
-            <File Id="nexploitcli.exe" Name="bright-cli.exe" KeyPath="yes" Source="$(var.SourceDir)\bright-cli.exe" Checksum="yes" />
+            <File Id="brightcli.exe" Name="bright-cli.exe" KeyPath="yes" Source="$(var.SourceDir)\bright-cli.exe" Checksum="yes" />
             <File Id="service.node" Name="service.node" Source="$(var.SourceDir)\service.node" Checksum="yes" />
             <File Id="raw.node" Name="raw.node" Source="$(var.SourceDir)\raw.node" Checksum="yes" />
             <File Id="roots.exe" Name="roots.exe" Source="$(var.SourceDir)\roots.exe" Checksum="yes" />


### PR DESCRIPTION
BREAKING CHANGE:

* The command-line interface previously known as `nexploit-cli` is no longer supported. It has been renamed to `bright-cli`:

  **Before**
  ```bash
  $ nexploit-cli -h
  ```
  **After**
  ```bash
  $ bright-cli -h
  ```
* The `--nogui` option for the `configure` command is no longer supported:
  **Before**
  ```bash
  $ nexploit-cli configure --nogui
  ```
  **After**
  ```bash
  $ bright-cli configure
  ```
* The `--api` and `--bus` options have been removed, use the `--cluster` option instead:
  **Before**
  ```bash
  $ nexploit-cli repeater --bus amqps://amq.app.brightsec.com:5672
  ```
  **After**
  ```bash
  $ bright-cli repeater --cluster app.brightsec.com
  ```

closes #378