### PR TITLE
chore: drop support for Linux distros with GCC runtime older than GCC 9

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -75,10 +75,10 @@ jobs:
             container: ubuntu:24.04
             executable: bright-cli-linux-x64
           - os: ubuntu-latest
-            container: rockylinux:8
+            container: rockylinux:9
             executable: bright-cli-linux-x64
           - os: ubuntu-latest
-            container: rockylinux:9
+            container: rockylinux:10
             executable: bright-cli-linux-x64
           - os: ubuntu-latest
             executable: bright-cli-linux-x64
@@ -267,16 +267,16 @@ jobs:
             container: ubuntu:22.04
             node: 24.11.1
           - os: ubuntu-latest
-            container: rockylinux:8
+            container: rockylinux:9
             node: 22
           - os: ubuntu-latest
-            container: rockylinux:8
+            container: rockylinux:9
             node: 24.11.1
           - os: ubuntu-latest
-            container: rockylinux:9
+            container: rockylinux:10
             node: 22
           - os: ubuntu-latest
-            container: rockylinux:9
+            container: rockylinux:10
             node: 24.11.1
 
     steps:


### PR DESCRIPTION
## What
Removes older Linux container entries from the test matrix and replaces them with newer equivalents that ship a sufficiently recent GCC runtime.

## Why
The `node-libcurl` native addon requires `GLIBCXX_3.4.26`, which is provided by **libstdc++ from GCC 9 or later**. On systems where the default GCC runtime is GCC 8 or below, bright-cli fails at startup with:

```
Error: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found
(required by .../@brightsec/node-libcurl/lib/binding/node_libcurl.node)
```

Rather than downgrading our C++ toolchain, we are explicitly dropping support for Linux distributions that ship a GCC runtime older than GCC 9.

## BREAKING CHANGE
**The minimum required libstdc++ version is now `GLIBCXX_3.4.26` (GCC 9+).**
Linux distributions whose default GCC runtime is older than GCC 9 are no longer supported. Users on such systems must upgrade their OS or manually update their `libstdc++` package.