### PR TITLE
fix(deps): bump @brightsec/node-libcurl to 5.0.12-0 (universal macOS fat binary)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.11.0-next.9",
       "license": "MIT",
       "dependencies": {
-        "@brightsec/node-libcurl": "5.0.6",
+        "@brightsec/node-libcurl": "5.0.12-0",
         "@modelcontextprotocol/sdk": "1.17.5",
         "@neuralegion/os-service": "^2.0.5",
         "@neuralegion/raw-socket": "^2.0.0",
@@ -681,9 +681,9 @@
       "license": "MIT"
     },
     "node_modules/@brightsec/node-libcurl": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@brightsec/node-libcurl/-/node-libcurl-5.0.6.tgz",
-      "integrity": "sha512-vnlLOSExMXEHP80cRJysEAxJzDorxyyxmbSQjhNZ289MYT61tJDnovgiGAQVAahCzUi/G5RSdhKMCh9bCAcf3A==",
+      "version": "5.0.12-0",
+      "resolved": "https://registry.npmjs.org/@brightsec/node-libcurl/-/node-libcurl-5.0.12-0.tgz",
+      "integrity": "sha512-yOU8/xxQ/aUI7ok0TfltfTna9JzRizSYUxGmqfFKFN9aYtttEE2XGgn+iNDq9ianWAP2APeXFpqN0yKjqISYhw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18761,9 +18761,9 @@
       "dev": true
     },
     "@brightsec/node-libcurl": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@brightsec/node-libcurl/-/node-libcurl-5.0.6.tgz",
-      "integrity": "sha512-vnlLOSExMXEHP80cRJysEAxJzDorxyyxmbSQjhNZ289MYT61tJDnovgiGAQVAahCzUi/G5RSdhKMCh9bCAcf3A==",
+      "version": "5.0.12-0",
+      "resolved": "https://registry.npmjs.org/@brightsec/node-libcurl/-/node-libcurl-5.0.12-0.tgz",
+      "integrity": "sha512-yOU8/xxQ/aUI7ok0TfltfTna9JzRizSYUxGmqfFKFN9aYtttEE2XGgn+iNDq9ianWAP2APeXFpqN0yKjqISYhw==",
       "requires": {
         "@mapbox/node-pre-gyp": "2.0.0",
         "env-paths": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.5",
-    "@brightsec/node-libcurl": "5.0.6",
+    "@brightsec/node-libcurl": "5.0.12-0",
     "@neuralegion/os-service": "^2.0.5",
     "@neuralegion/raw-socket": "^2.0.0",
     "@sentry/node": "^7.120.0",


### PR DESCRIPTION
## Summary

Bumps `@brightsec/node-libcurl` from `5.0.6` to `5.0.12-0`.

## Root cause

The `5.0.6` (and earlier pre-release) builds thin-sliced the `darwin-arm64` tarball to only the arm64 slice via `lipo -thin arm64`. When `pkg` bundles native addons it treats them as opaque assets and does **not** re-lipo them, so the arm64-only `.node` file got loaded inside a `node22-macos-x64` executable on the arm64 CI runner → `ERR_DLOPEN_FAILED: have 'arm64', need 'x86_64h' or 'x86_64'`.

## Fix (in node-libcurl)

[NeuraLegion/node-libcurl#22](https://github.com/NeuraLegion/node-libcurl/pull/22): the `darwin-arm64` tarball now ships the full fat binary (arm64 + x86_64) instead of thinning it — matching the approach used by `node-raw-socket`.

## What this PR does

- Bumps `@brightsec/node-libcurl` to `5.0.12-0` (published to npm `next` tag)
- Updates `package-lock.json`

Closes the arch mismatch that caused the `macos-14` arm64 runner regression.